### PR TITLE
Bump Docker base image to Node 24 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM node:20-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 ENV NODE_ENV=production
 
@@ -12,7 +12,7 @@ COPY . .
 RUN npm run build
 
 # runtime stage
-FROM node:20-alpine AS runner
+FROM node:24-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=3000

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:24-alpine
 WORKDIR /app
 ENV NODE_ENV=development
 ENV PORT=3000


### PR DESCRIPTION
## Summary
- Bump `Dockerfile` (both build and runtime stages) and `Dockerfile.dev` from `node:20-alpine` to `node:24-alpine`, the current active Node LTS line
- No application code changes

## Test plan
- [x] Verified `npm ci` and `npm run build` succeed cleanly under Node 24 (via `nvm`)
- [x] Verified in dev and production mode (Playwright, console-error capture) that the day page renders with no hydration mismatches on Node 24
- [x] Verified a full local `docker compose build --no-cache && docker compose up` on Node 24 — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)