### PR TITLE
Bump actions/checkout from v3 to v7

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Log in to GHCR
         run: echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v3 to v7 in `deploy.yml` to clear the Node 20 deprecation warning (GitHub Actions now force-runs actions on Node 24; v3 was still declaring the old runtime)

## Test plan
- [x] Reviewed release notes v4 through v7 for breaking changes — none apply: v5's runner-version requirement only affects self-hosted runners (this workflow uses `ubuntu-latest`), and v7's fork-PR restriction only affects `pull_request_target`/`workflow_run` triggers (this workflow only triggers on `push` to `main`)
- [x] No `with:` parameters are used in this step, so there's no parameter surface affected by version changes
- [ ] Will confirm the workflow run is green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)