### PR TITLE
Deep ochre gold, app-wide font scaling, gold chapter-number markers

### DIFF
--- a/__tests__/app/DayPage.spec.tsx
+++ b/__tests__/app/DayPage.spec.tsx
@@ -130,6 +130,23 @@ describe("DayPage day navigation", () => {
 		);
 	});
 
+	it("gives the day heading and Prev/Next Day links the app-wide scale class", async () => {
+		render(<DayPage />);
+
+		await waitFor(() =>
+			expect(screen.getByTestId("passage-PSA-32")).toBeInTheDocument()
+		);
+		expect(screen.getByRole("heading", { level: 1 })).toHaveClass(
+			"app-text-heading"
+		);
+		expect(screen.getByRole("link", { name: /Prev Day/ })).toHaveClass(
+			"app-text-nav"
+		);
+		expect(screen.getByRole("link", { name: /Next Day/ })).toHaveClass(
+			"app-text-nav"
+		);
+	});
+
 	it("wraps Prev Day to the previous month's last day at the start of a month", async () => {
 		mockPathname.mockReturnValue("/1/1");
 		render(<DayPage />);

--- a/__tests__/components/OptionsPanel.spec.tsx
+++ b/__tests__/components/OptionsPanel.spec.tsx
@@ -92,6 +92,14 @@ describe("OptionsPanel", () => {
 			expect(screen.getByText("LANGUAGE")).toBeInTheDocument();
 		});
 
+		it("gives the LANGUAGE label and its rows the app-wide scale classes", () => {
+			renderPanel();
+			expect(screen.getByText("LANGUAGE")).toHaveClass("app-text-label");
+			expect(screen.getByRole("button", { name: "English" })).toHaveClass(
+				"app-text-row"
+			);
+		});
+
 		it("renders all 7 language options as buttons", () => {
 			renderPanel();
 			["Dutch", "English", "French", "German", "Polish", "Spanish", "Swedish"].forEach(
@@ -273,6 +281,14 @@ describe("OptionsPanel", () => {
 			expect(screen.getByRole("button", { name: "Source Serif 4" })).toBeInTheDocument();
 		});
 
+		it("gives the READING FONT label and swatches the app-wide scale classes", () => {
+			renderPanel();
+			expect(screen.getByText("READING FONT")).toHaveClass("app-text-label");
+			expect(screen.getByRole("button", { name: "EB Garamond" })).toHaveClass(
+				"app-text-swatch"
+			);
+		});
+
 		it("defaults to EB Garamond when no bodyFont is stored", async () => {
 			renderPanel();
 			await waitFor(() =>
@@ -325,6 +341,11 @@ describe("OptionsPanel", () => {
 			expect(screen.getByRole("button", { name: "Small text size" })).toBeInTheDocument();
 			expect(screen.getByRole("button", { name: "Medium text size" })).toBeInTheDocument();
 			expect(screen.getByRole("button", { name: "Large text size" })).toBeInTheDocument();
+		});
+
+		it("gives the TEXT SIZE label the app-wide scale class (preview buttons keep their fixed demo sizes)", () => {
+			renderPanel();
+			expect(screen.getByText("TEXT SIZE")).toHaveClass("app-text-label");
 		});
 
 		it("previews each option at its own size", () => {

--- a/__tests__/components/ReadingTabs.spec.tsx
+++ b/__tests__/components/ReadingTabs.spec.tsx
@@ -50,6 +50,15 @@ describe("ReadingTabs", () => {
 		expect(inactiveUnderline).not.toHaveClass("bg-primary");
 	});
 
+	it("gives each tab label the app-wide scale class so Text Size affects tabs too", () => {
+		render(
+			<ReadingTabs readings={readings} activeIndex={0} onSelect={jest.fn()} />
+		);
+
+		expect(screen.getByTestId("reading-tab-label-0")).toHaveClass("app-text-tab");
+		expect(screen.getByTestId("reading-tab-label-1")).toHaveClass("app-text-tab");
+	});
+
 	it("calls onSelect with the tab index when a tab is clicked", async () => {
 		const onSelect = jest.fn();
 		render(

--- a/__tests__/components/Verse.spec.tsx
+++ b/__tests__/components/Verse.spec.tsx
@@ -33,6 +33,28 @@ describe("Verse Component", () => {
 		).toBeInTheDocument();
 	});
 
+	it("renders the leading chapter number in gold, matching the verse-number color", () => {
+		const line: ChapterVerse = {
+			type: "verse",
+			number: 1,
+			content: ["In the beginning God created the heavens and the earth."],
+		};
+		const { getByText } = render(<Verse line={line} bookChapterNumber={1} />);
+		expect(getByText("1")).toHaveClass("text-gold");
+		expect(getByText("1")).not.toHaveClass("text-primary");
+	});
+
+	it("renders the leading chapter number in gold for words of Jesus too", () => {
+		const line: ChapterVerse = {
+			type: "verse",
+			number: 1,
+			content: [{ wordsOfJesus: true, text: "I am the way" } as FormattedText],
+		};
+		const { getByText } = render(<Verse line={line} bookChapterNumber={5} />);
+		expect(getByText("5")).toHaveClass("text-gold");
+		expect(getByText("5")).not.toHaveClass("text-primary");
+	});
+
 	it("does not italicise regular prose verse text", () => {
 		const line: ChapterVerse = {
 			type: "verse",

--- a/__tests__/contexts/SelectionsProvider.spec.tsx
+++ b/__tests__/contexts/SelectionsProvider.spec.tsx
@@ -1,0 +1,61 @@
+import { render, screen, act } from "@testing-library/react";
+import { useContext } from "react";
+import {
+	SelectionsProvider,
+	SelectionsContext,
+	SelectionsDispatchContext,
+} from "@/app/contexts";
+
+const TestConsumer = () => {
+	const selections = useContext(SelectionsContext);
+	const dispatch = useContext(SelectionsDispatchContext);
+	return (
+		<div>
+			<span data-testid="font-size">{selections.fontSize ?? "unset"}</span>
+			<button onClick={() => dispatch({ type: "SET_FONT_SIZE", payload: "large" })}>
+				set large
+			</button>
+			<button onClick={() => dispatch({ type: "SET_FONT_SIZE", payload: "small" })}>
+				set small
+			</button>
+		</div>
+	);
+};
+
+const renderWithProvider = () =>
+	render(
+		<SelectionsProvider>
+			<TestConsumer />
+		</SelectionsProvider>
+	);
+
+beforeEach(() => {
+	document.documentElement.removeAttribute("data-font-scale");
+});
+
+describe("SelectionsProvider font-scale attribute", () => {
+	it("defaults document.documentElement's data-font-scale to medium before a selection is made", () => {
+		renderWithProvider();
+		expect(document.documentElement.dataset.fontScale).toBe("medium");
+	});
+
+	it("sets data-font-scale to large when fontSize becomes large", async () => {
+		renderWithProvider();
+
+		await act(async () => {
+			screen.getByRole("button", { name: "set large" }).click();
+		});
+
+		expect(document.documentElement.dataset.fontScale).toBe("large");
+	});
+
+	it("sets data-font-scale to small when fontSize becomes small", async () => {
+		renderWithProvider();
+
+		await act(async () => {
+			screen.getByRole("button", { name: "set small" }).click();
+		});
+
+		expect(document.documentElement.dataset.fontScale).toBe("small");
+	});
+});

--- a/__tests__/home.spec.tsx
+++ b/__tests__/home.spec.tsx
@@ -41,4 +41,13 @@ describe("Home", () => {
 		const dayLink = screen.getByTestId("date:December-2").closest("a");
 		expect(dayLink).toHaveClass("text-primary");
 	});
+
+	it("gives the heading and reading reference lines the app-wide scale classes", async () => {
+		render(<Home />);
+		expect(screen.getByText("Lutheran Lectionary")).toHaveClass("app-text-heading-lg");
+
+		await userEvent.click(screen.getByRole("button", { name: "December" }));
+		expect(screen.getByTestId("reading1:December-2")).toHaveClass("app-text-caption");
+		expect(screen.getByTestId("reading2:December-2")).toHaveClass("app-text-caption");
+	});
 });

--- a/__tests__/utils/contrast.spec.ts
+++ b/__tests__/utils/contrast.spec.ts
@@ -1,0 +1,20 @@
+import { contrastRatio } from "@/app/utils";
+
+describe("contrastRatio", () => {
+	it("computes the WCAG contrast ratio between two hex colors", () => {
+		// black on white is the maximum possible ratio, 21:1
+		expect(contrastRatio("#000000", "#FFFFFF")).toBeCloseTo(21, 0);
+	});
+
+	it("returns 1 for identical colors", () => {
+		expect(contrastRatio("#A6873A", "#A6873A")).toBeCloseTo(1, 5);
+	});
+
+	it("flags the current light-theme gold as failing WCAG AA (4.5:1) against the light background", () => {
+		expect(contrastRatio("#A6873A", "#F3ECDD")).toBeLessThan(4.5);
+	});
+
+	it("confirms the new deep ochre gold passes WCAG AA against the light background", () => {
+		expect(contrastRatio("#7A5C1A", "#F3ECDD")).toBeGreaterThanOrEqual(4.5);
+	});
+});

--- a/docs/changes/liturgical-contrast-and-scaling-summary.md
+++ b/docs/changes/liturgical-contrast-and-scaling-summary.md
@@ -1,0 +1,56 @@
+# Change Summary: Deep Ochre Gold, App-Wide Font Scaling, ESV Chapter-Number Fix
+
+Status: **not started** — spec and plan only, no implementation yet.
+
+Follow-up to the shipped tab-contrast/font-settings work; addresses three
+issues raised in review of that feature.
+
+## What will change
+
+1. **Light-theme gold contrast** — `--color-gold` in `globals.css` moves
+   from `#A6873A` (2.9:1 against the light background, fails WCAG AA) to a
+   deep ochre `#7A5C1A` (5.3:1, passes). Single CSS-variable edit; dark
+   theme untouched. `src/app/globals.css`, new
+   `src/app/utils/contrast.ts`.
+2. **App-wide font scaling** — the existing Text Size setting (currently
+   passage-body-only) becomes a document-wide multiplier via an
+   `--app-font-scale` CSS variable set on `<html>`, applied to headings,
+   tab labels, options-panel text, and nav links in addition to passage
+   body text. No new setting/localStorage key — reuses the existing
+   `fontSize` selection. `src/app/contexts/SelectionsProvider.tsx`,
+   `src/app/globals.css`, `src/app/components/AppHeader.tsx`,
+   `src/app/components/ReadingTabs.tsx`,
+   `src/app/components/OptionsPanel.tsx`, `src/app/page.tsx`,
+   `src/app/[month]/[day]/page.tsx`.
+3. **ESV chapter-number marker fix** — ESV HTML's `.chapter-num` (the
+   leading "56:1" on a reading's first verse) currently has no styling and
+   inherits body-text color. Adds a CSS rule matching the non-ESV
+   `Verse.tsx` treatment (Cormorant, 600 weight, 24px, primary color).
+   `src/app/globals.css`.
+
+## Net new state
+
+- None — no new `Selections` fields. Font scaling reuses the existing
+  `fontSize` value; gold and chapter-num are CSS-only.
+
+## Explicitly not touched
+
+- Seasonal/liturgical-calendar color theming.
+- Making scale factors (0.9/1/1.15) user-configurable beyond the existing
+  Small/Medium/Large control.
+
+## Process
+
+Same as the prior feature: hybrid outside-in TDD (component/context-level
+failing test first, dropping to a pure-function unit test only where no
+component boundary applies — contrast-ratio math, CSS-only rules). Every
+stage ends with a full-suite QA pass, a spec re-check, a browser
+spot-check, and a rubber-duck review; up to 3 correction attempts per
+stage before handing back rather than proceeding. Each stage is an
+independent, individually-revertable commit. Full details in the plan's
+Process section.
+
+## Docs
+
+- Spec: `docs/specs/liturgical-contrast-and-scaling.md`
+- Plan: `docs/plans/liturgical-contrast-and-scaling-plan.md`

--- a/docs/plans/liturgical-contrast-and-scaling-plan.md
+++ b/docs/plans/liturgical-contrast-and-scaling-plan.md
@@ -1,0 +1,140 @@
+# Plan: Deep Ochre Gold, App-Wide Font Scaling, ESV Chapter-Number Fix
+
+Spec: `docs/specs/liturgical-contrast-and-scaling.md`. Three independent
+concerns; stages are ordered so each is its own commit and can be reverted
+individually without affecting the others (no stage depends on another's
+implementation, only on the branch being current).
+
+## Process
+
+Same discipline as `docs/plans/tab-contrast-font-settings-plan.md`:
+
+**Hybrid outside-in TDD** for all new code, applied per stage:
+- Prefer a test at the highest boundary that exercises the change the way a
+  real consumer does (component render, context wiring, dispatched action).
+- Drop to a pure-function unit test only where component testing is
+  impractical (Stage 1's contrast-ratio check; a CSS-only rule has no JS
+  boundary to test against at all — see Stage 4).
+- Within a stage: write the failing test first, implement until green, then
+  move on.
+
+**End of every stage**, before moving on:
+1. **QA pass** — run the full test suite, re-read the diff against the spec
+   section it implements, and where the stage touches rendered output,
+   spot-check in the browser rather than trusting green tests alone.
+2. **Rubber-duck review** — walk back through what the stage was supposed to
+   do, what was implemented, and why, looking specifically for mismatches
+   with the spec, uncovered edge cases, and tests written to match the
+   implementation instead of the spec.
+3. If QA or rubber-duck review surfaces a problem, fix it and repeat
+   (max 3 attempts for that stage). If still unresolved after 3 attempts,
+   stop and hand the stage back with a clear description of what's failing
+   and what's been tried — do not proceed to the next stage.
+
+## Stage 1 — Deep ochre gold (light theme only)
+
+1. Write failing test for a new `contrastRatio(fg, bg)` pure utility
+   (`src/app/utils/contrast.ts`) covering: known ratio for the current gold
+   `#A6873A` vs `#F3ECDD` (≈2.9, fails 4.5 threshold) and for the new ochre
+   `#7A5C1A` vs `#F3ECDD` (≥4.5, passes).
+2. Implement `contrastRatio` (WCAG relative-luminance formula).
+3. Change `--color-gold` under `:root` in `globals.css` from `#A6873A` to
+   `#7A5C1A`. Leave `.dark { --color-gold: ... }` untouched.
+4. QA + rubber-duck review. Confirm in-browser (light theme) that verse
+   numbers, tabs, panel labels, subtitle, and nav links all read the new
+   color (they all consume the same token, so one edit should be
+   sufficient — verify no component hardcodes the old hex instead of the
+   variable). Confirm dark theme is visually unchanged.
+
+## Stage 2 — Font-scale infrastructure
+
+1. Write failing test in `SelectionsProvider.spec.tsx` (new file): when
+   `selections.fontSize` changes, `document.documentElement` gets a
+   `data-font-scale="small" | "medium" | "large"` attribute (defaults to
+   `"medium"` before a selection is loaded).
+2. In `SelectionsProvider.tsx`, add a `useEffect` that sets
+   `document.documentElement.dataset.fontScale = selections.fontSize ??
+   "medium"` whenever `selections.fontSize` changes.
+3. Add to `globals.css`:
+   ```css
+   :root { --app-font-scale: 1; }
+   html[data-font-scale="small"] { --app-font-scale: 0.9; }
+   html[data-font-scale="large"] { --app-font-scale: 1.15; }
+   ```
+4. QA + rubber-duck review. Confirm in-browser via devtools that the
+   `<html>` attribute updates immediately when Text Size is changed in the
+   options panel, and persists correctly on reload (existing `fontSize`
+   localStorage key already restores `selections.fontSize` on mount).
+
+## Stage 3 — Apply scale to chrome text
+
+1. Write failing tests asserting the affected elements use the new
+   scale-aware CSS classes (class-name assertions; jsdom doesn't compute
+   `calc()`, so this stage's real verification is the Stage 3 browser
+   check, not the unit test):
+   - `AppHeader.spec.tsx`: title uses `.app-text-heading` (or equivalent).
+   - `ReadingTabs.spec.tsx`: tab label uses `.app-text-tab`.
+   - `OptionsPanel.spec.tsx`: section labels use `.app-text-label`.
+   - Home page / day page nav link and heading tests: same pattern.
+2. Add named scale-aware utility classes to `globals.css`, e.g.:
+   ```css
+   .app-text-heading   { font-size: calc(38px * var(--app-font-scale)); }
+   .app-text-tab       { font-size: calc(16.5px * var(--app-font-scale)); }
+   .app-text-label     { font-size: calc(15px * var(--app-font-scale)); }
+   .app-text-nav       { font-size: calc(16px * var(--app-font-scale)); }
+   ```
+   (exact set/naming driven by the components actually touched; keep each
+   class tied to the one hardcoded px value it replaces so the visual
+   baseline at `medium` is unchanged).
+3. Replace the corresponding `text-[Npx]` Tailwind arbitrary classes in
+   `AppHeader.tsx`, `ReadingTabs.tsx`, `OptionsPanel.tsx`, `page.tsx`,
+   `[month]/[day]/page.tsx` with the new classes, keeping every other
+   class (color, weight, family) unchanged.
+4. QA + rubber-duck review. Confirm in-browser that switching Text Size
+   noticeably resizes headings, tabs, panel labels, and nav links together,
+   that `medium` looks pixel-identical to the pre-change baseline
+   (screenshot diff or side-by-side), and that passage body text (already
+   scaled independently since the prior feature) doesn't double-scale.
+
+## Stage 4 — ESV chapter-number color fix
+
+1. No dedicated unit test — this is a CSS-only rule addition mirroring an
+   existing non-ESV treatment; there's no JS boundary to assert against; per
+   Process, config/CSS-only stages are verified visually instead (same
+   precedent as Stage 4, font loading, in the prior plan).
+2. Add to `globals.css`:
+   ```css
+   .esv-passage .chapter-num {
+     font-family: var(--font-cormorant), Georgia, serif;
+     font-weight: 600;
+     font-style: normal;
+     font-size: 24px;
+     color: var(--color-primary);
+   }
+   ```
+3. QA + rubber-duck review. Open an ESV reading whose first verse starts a
+   new chapter (e.g. `/7/30` on ESV) in-browser and confirm the leading
+   `56:1`-style marker renders large/bold/burgundy, distinct from the
+   small gold verse markers after it, matching the non-ESV rendering of the
+   same passage.
+
+## Stage 5 — End-to-end verification
+
+1. Run full unit/test suite + type-check.
+2. Manual browser pass:
+   - Light theme: confirm gold text throughout meets contrast expectations
+     visually (no washed-out low-contrast text remaining).
+   - Switch Text Size through all three tiers: confirm headings, tabs,
+     panel, nav, and passage body all resize together, and the change
+     survives a reload.
+   - Dark theme: confirm unaffected by both the gold and scale changes.
+   - ESV `/7/30`: confirm chapter-number marker fix.
+3. `/code-review` pass before calling it done.
+4. QA + rubber-duck review covering the whole feature set end-to-end — the
+   final gate before handing back as done.
+
+## Explicitly out of scope for this pass
+
+- Seasonal liturgical-calendar color theming.
+- Making the 0.9/1/1.15 scale factors user-configurable beyond the existing
+  Small/Medium/Large control.

--- a/docs/specs/liturgical-contrast-and-scaling.md
+++ b/docs/specs/liturgical-contrast-and-scaling.md
@@ -65,13 +65,16 @@ covered), icon sizes, layout spacing/padding.
 `<b class="verse-num inline">2&nbsp;</b>` for later verses.
 `globals.css` has a `.esv-passage .verse-num` rule (13px, gold) but no rule
 for `.chapter-num`, so it inherits the paragraph's default body-text color —
-it doesn't read as a marker at all. The non-ESV path (`Verse.tsx`) already
-distinguishes the leading chapter number: `font-cormorant font-semibold
-not-italic text-[24px] text-primary`.
+it doesn't read as a marker at all.
 
-**Change:** add `.esv-passage .chapter-num` to `globals.css`, mirroring
-`Verse.tsx`'s treatment: Cormorant, 600 weight, not italic, 24px,
-`var(--color-primary)`. No JS/logic change — CSS parity only.
+**Change:** add `.esv-passage .chapter-num` to `globals.css` — Cormorant,
+600 weight, not italic, 24px, `var(--color-gold)` — and update the
+equivalent non-ESV chapter-number spans in `Verse.tsx` (prose and
+words-of-Christ branches) from `text-primary` to `text-gold` to match.
+Gold rather than primary/burgundy so the large chapter marker reads as
+part of the same verse-numbering system as the small gold verse numbers
+next to it, instead of a differently-colored heading. No other JS/logic
+change.
 
 ## Acceptance criteria
 
@@ -82,9 +85,9 @@ not-italic text-[24px] text-primary`.
   and persists across reload (existing `fontSize` localStorage key, no new
   key needed).
 - On an ESV reading, the leading `<chapter>:<verse>` marker (e.g. "56:1")
-  renders large/bold/burgundy, matching the non-ESV first-verse chapter
-  number, and is visually distinct from the small gold verse-number
-  markers that follow it.
+  renders large/bold/gold, matching the non-ESV first-verse chapter number,
+  using the same gold as the small verse-number markers that follow it
+  (just larger, so it still reads as the chapter marker).
 
 ## Out of scope
 

--- a/docs/specs/liturgical-contrast-and-scaling.md
+++ b/docs/specs/liturgical-contrast-and-scaling.md
@@ -1,0 +1,93 @@
+# Spec: Deep Ochre Gold, App-Wide Font Scaling, ESV Chapter-Number Fix
+
+Follow-up to `docs/specs/tab-contrast-font-settings.md`. Three independent
+concerns raised in review of that work.
+
+## 1. Replace light-theme gold with deep ochre
+
+**Problem:** `--color-gold: #A6873A` (light theme) on `--color-bg: #F3ECDD`
+measures **2.9:1** contrast — fails WCAG AA (4.5:1) for normal text. Gold is
+used as actual text color in many places: verse-number superscripts, the
+Hebrew subtitle caption, inactive reading tabs, options-panel section
+labels, Prev/Next Day nav links, home-page calendar reference lines, the
+options-panel close icon.
+
+**Decision:** darken the existing token rather than shift hue. A hue shift
+toward liturgical violet/green would imply a seasonal-color meaning the app
+doesn't model (liturgical colors track the church calendar, not a static
+UI accent) — that's a bigger product decision than a contrast fix.
+Staying in the gold family preserves the existing visual identity.
+
+**Change:** `--color-gold` under `:root` (light theme only) becomes
+`#7A5C1A` ("deep ochre"), measuring **5.3:1** against `--color-bg` — passes
+AA. Dark theme's `--color-gold: #D4B25A` is unchanged (already 8.3:1).
+
+No component changes — every consumer reads the CSS variable via the
+existing `gold` Tailwind color / `var(--color-gold)`, so this is a
+single-token edit.
+
+## 2. App-wide font scaling
+
+**Problem:** the existing Text Size setting (`docs/specs/tab-contrast-font-settings.md`
+item 3) only scales passage body text (`Verse.tsx`, `EsvPassage.tsx`).
+Headings, tabs, options panel, and nav chrome stay fixed size, so a user
+picking "Large" for readability gets no relief outside the verse text.
+
+**Decision (Option B — global scale):** Text Size becomes a document-wide
+multiplier. A CSS custom property, `--app-font-scale`, is set at the
+`<html>` (or a top-level client wrapper) based on `selections.fontSize`:
+
+| fontSize | `--app-font-scale` |
+|---|---|
+| small | `0.9` |
+| medium | `1` (default) |
+| large | `1.15` |
+
+Every chrome text size that should scale is expressed as
+`calc(<base-px> * var(--app-font-scale))` instead of a bare `text-[Npx]`
+Tailwind arbitrary value, via small named CSS utility classes in
+`globals.css` (Tailwind arbitrary values can't reference a runtime CSS
+variable multiplier directly). Existing passage-body scaling
+(`readingStyle.ts` → `fontSizeClass`) is left as-is; it already has its own
+three fixed sizes and doesn't need to also multiply by the new scale.
+
+**In scope for scaling:** page/day headings (`h1` on home + day page), tab
+labels, options-panel section labels and row text, Prev/Next Day nav links,
+home-page calendar reference lines, `AppHeader` title.
+
+**Out of scope:** the existing passage body text-size control (already
+covered), icon sizes, layout spacing/padding.
+
+## 3. ESV chapter:verse marker color
+
+**Problem:** ESV HTML marks the first verse of a passage with
+`<b class="chapter-num">56:1&nbsp;</b>`, distinct from
+`<b class="verse-num inline">2&nbsp;</b>` for later verses.
+`globals.css` has a `.esv-passage .verse-num` rule (13px, gold) but no rule
+for `.chapter-num`, so it inherits the paragraph's default body-text color —
+it doesn't read as a marker at all. The non-ESV path (`Verse.tsx`) already
+distinguishes the leading chapter number: `font-cormorant font-semibold
+not-italic text-[24px] text-primary`.
+
+**Change:** add `.esv-passage .chapter-num` to `globals.css`, mirroring
+`Verse.tsx`'s treatment: Cormorant, 600 weight, not italic, 24px,
+`var(--color-primary)`. No JS/logic change — CSS parity only.
+
+## Acceptance criteria
+
+- Light-theme gold text (verse numbers, tabs, subtitle, panel labels, nav
+  links) measures ≥ 4.5:1 against `--color-bg`. Dark theme unchanged.
+- Switching Text Size in the options panel visibly resizes headings, tab
+  labels, options-panel text, and nav links — not just passage body text —
+  and persists across reload (existing `fontSize` localStorage key, no new
+  key needed).
+- On an ESV reading, the leading `<chapter>:<verse>` marker (e.g. "56:1")
+  renders large/bold/burgundy, matching the non-ESV first-verse chapter
+  number, and is visually distinct from the small gold verse-number
+  markers that follow it.
+
+## Out of scope
+
+- Any seasonal/liturgical-calendar color theming (violet for Advent, etc.).
+- Extending the numeric scale values (0.9/1/1.15) to be user-configurable
+  beyond the existing three-tier Small/Medium/Large control.

--- a/src/app/[month]/[day]/page.tsx
+++ b/src/app/[month]/[day]/page.tsx
@@ -118,7 +118,7 @@ const DayPage = () => {
 
 	return (
 		<div className="pb-8">
-			<h1 className="font-cormorant font-semibold text-[38px] text-primary text-center mt-6 mb-2">
+			<h1 className="font-cormorant font-semibold app-text-heading text-primary text-center mt-6 mb-2">
 				{month.name} {dayParameter}
 			</h1>
 			<hr className="w-[60px] border-t border-gold mx-auto mb-7" />
@@ -134,14 +134,14 @@ const DayPage = () => {
 			<div className="flex items-center justify-center gap-9 mt-14 pt-[22px] border-t border-divider">
 				<Link
 					href={`/${prevDay.monthIndex + 1}/${prevDay.day}`}
-					className="font-eb-garamond italic text-[16px] text-gold"
+					className="font-eb-garamond italic app-text-nav text-gold"
 				>
 					&lsaquo; Prev Day
 				</Link>
 				<ScrollToTopButton />
 				<Link
 					href={`/${nextDay.monthIndex + 1}/${nextDay.day}`}
-					className="font-eb-garamond italic text-[16px] text-gold"
+					className="font-eb-garamond italic app-text-nav text-gold"
 				>
 					Next Day &rsaquo;
 				</Link>

--- a/src/app/components/OptionsPanel.tsx
+++ b/src/app/components/OptionsPanel.tsx
@@ -180,7 +180,7 @@ export const OptionsPanel: React.FC<OptionsPanelProps> = ({
 				</div>
 
 				<div className="px-6 pb-4">
-					<p className="font-cormorant font-semibold text-[15px] uppercase tracking-[0.5px] text-gold mb-2">
+					<p className="font-cormorant font-semibold app-text-label uppercase tracking-[0.5px] text-gold mb-2">
 						LANGUAGE
 					</p>
 					<div className="flex flex-col gap-1">
@@ -189,7 +189,7 @@ export const OptionsPanel: React.FC<OptionsPanelProps> = ({
 								key={language}
 								aria-pressed={selections.languageName === language}
 								onClick={() => handleLanguageClick(language)}
-								className={`text-left px-[14px] py-[10px] rounded-sm border font-eb-garamond text-[17px] ${
+								className={`text-left px-[14px] py-[10px] rounded-sm border font-eb-garamond app-text-row ${
 									selections.languageName === language
 										? "border-primary text-primary font-semibold"
 										: "border-border"
@@ -202,7 +202,7 @@ export const OptionsPanel: React.FC<OptionsPanelProps> = ({
 				</div>
 
 				<div className="px-6">
-					<p className="font-cormorant font-semibold text-[15px] uppercase tracking-[0.5px] text-gold mb-2">
+					<p className="font-cormorant font-semibold app-text-label uppercase tracking-[0.5px] text-gold mb-2">
 						TRANSLATION
 					</p>
 					<div className="flex flex-col gap-1">
@@ -212,7 +212,7 @@ export const OptionsPanel: React.FC<OptionsPanelProps> = ({
 								data-testid={`translation-row-${translation.id}`}
 								aria-pressed={selections.translationId === translation.id}
 								onClick={() => handleTranslationClick(translation.id)}
-								className={`text-left px-[14px] py-[10px] rounded-sm border font-eb-garamond text-[17px] ${
+								className={`text-left px-[14px] py-[10px] rounded-sm border font-eb-garamond app-text-row ${
 									selections.translationId === translation.id
 										? "border-primary text-primary font-semibold"
 										: "border-border"
@@ -225,7 +225,7 @@ export const OptionsPanel: React.FC<OptionsPanelProps> = ({
 				</div>
 
 				<div className="px-6 pt-4">
-					<p className="font-cormorant font-semibold text-[15px] uppercase tracking-[0.5px] text-gold mb-2">
+					<p className="font-cormorant font-semibold app-text-label uppercase tracking-[0.5px] text-gold mb-2">
 						READING FONT
 					</p>
 					<div className="flex gap-[10px]">
@@ -235,7 +235,7 @@ export const OptionsPanel: React.FC<OptionsPanelProps> = ({
 								data-testid={`body-font-row-${option.key}`}
 								aria-pressed={selections.bodyFont === option.key}
 								onClick={() => handleBodyFontClick(option.key)}
-								className={`flex-1 text-center px-2 py-3 rounded-sm border italic text-[16px] ${option.stack} ${
+								className={`flex-1 text-center px-2 py-3 rounded-sm border italic app-text-swatch ${option.stack} ${
 									selections.bodyFont === option.key
 										? "border-primary text-primary"
 										: "border-border"
@@ -248,7 +248,7 @@ export const OptionsPanel: React.FC<OptionsPanelProps> = ({
 				</div>
 
 				<div className="px-6 pt-4">
-					<p className="font-cormorant font-semibold text-[15px] uppercase tracking-[0.5px] text-gold mb-2">
+					<p className="font-cormorant font-semibold app-text-label uppercase tracking-[0.5px] text-gold mb-2">
 						TEXT SIZE
 					</p>
 					<div className="flex gap-[10px]">

--- a/src/app/components/ReadingTabs.tsx
+++ b/src/app/components/ReadingTabs.tsx
@@ -26,7 +26,7 @@ export const ReadingTabs: React.FC<ReadingTabsProps> = ({
 					>
 						<span
 							data-testid={`reading-tab-label-${index}`}
-							className={`font-eb-garamond italic text-[16.5px] ${
+							className={`font-eb-garamond italic app-text-tab ${
 								isActive ? "font-semibold text-primary" : "text-gold"
 							}`}
 						>

--- a/src/app/components/Verse.tsx
+++ b/src/app/components/Verse.tsx
@@ -29,7 +29,7 @@ export const Verse: React.FC<VerseProps> = ({ line, bookChapterNumber }) => {
 					verse = (
 						<p data-testid={testId} key={verseKey} className={`${bodyClass} leading-[1.75] text-body-text`}>
 							{line.number === 1 && verseLineIndex == 0 ? (
-								<span className="font-cormorant font-semibold not-italic text-[24px] text-primary">
+								<span className="font-cormorant font-semibold not-italic text-[24px] text-gold">
 									{`${bookChapterNumber}`}&nbsp;
 								</span>
 							) : (
@@ -62,7 +62,7 @@ export const Verse: React.FC<VerseProps> = ({ line, bookChapterNumber }) => {
 					verse = (
 						<p className={`${bodyClass} leading-[1.75] text-words-of-christ`} data-testid={testId} key={verseKey}>
 							{line.number === 1 ? (
-								<span className="font-cormorant font-semibold not-italic text-[24px] text-primary">
+								<span className="font-cormorant font-semibold not-italic text-[24px] text-gold">
 									{`${bookChapterNumber}`}&nbsp;
 								</span>
 							) : (

--- a/src/app/contexts/SelectionsProvider.tsx
+++ b/src/app/contexts/SelectionsProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useReducer } from "react";
+import { createContext, useEffect, useReducer } from "react";
 import { Selections } from "@/app/interfaces";
 import { selectionsReducer, SelectionsAction } from "@/app/reducers";
 
@@ -23,6 +23,10 @@ export const SelectionsProvider = ({
 		languageName: "",
 		translationId: "",
 	});
+
+	useEffect(() => {
+		document.documentElement.dataset.fontScale = selections.fontSize ?? "medium";
+	}, [selections.fontSize]);
 
 	return (
 		<SelectionsContext.Provider value={selections}>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -92,6 +92,14 @@ html[data-font-scale="large"] {
 }
 
 
+.esv-passage .chapter-num {
+  font-family: var(--font-cormorant), Georgia, serif;
+  font-weight: 600;
+  font-style: normal;
+  font-size: 24px;
+  color: var(--color-primary);
+}
+
 .esv-passage .verse-num {
   font-family: var(--font-eb-garamond), Georgia, serif;
   font-style: normal;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,7 +7,7 @@
   --color-card: #FBF7EC;
   --color-primary: #5C1F1F;
   --color-primary-hover: #7A2E2E;
-  --color-gold: #A6873A;
+  --color-gold: #7A5C1A;
   --color-body-text: #2E2A20;
   --color-border: #C9BC9C;
   --color-divider: #D9CEB0;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -35,6 +35,21 @@ body {
   transition: background 0.35s ease, color 0.35s ease;
 }
 
+/* App-wide chrome text scale, driven by the Text Size selection via the
+   data-font-scale attribute SelectionsProvider sets on <html>. Passage body
+   text has its own independent scaling (readingStyle.ts fontSizeClass). */
+:root {
+  --app-font-scale: 1;
+}
+
+html[data-font-scale="small"] {
+  --app-font-scale: 0.9;
+}
+
+html[data-font-scale="large"] {
+  --app-font-scale: 1.15;
+}
+
 /* ESV passage HTML */
 .esv-passage p {
   font-family: var(--font-eb-garamond), Georgia, serif;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -50,6 +50,15 @@ html[data-font-scale="large"] {
   --app-font-scale: 1.15;
 }
 
+.app-text-heading-lg { font-size: calc(44px * var(--app-font-scale)); }
+.app-text-heading    { font-size: calc(38px * var(--app-font-scale)); }
+.app-text-tab        { font-size: calc(16.5px * var(--app-font-scale)); }
+.app-text-label      { font-size: calc(15px * var(--app-font-scale)); }
+.app-text-row        { font-size: calc(17px * var(--app-font-scale)); }
+.app-text-swatch     { font-size: calc(16px * var(--app-font-scale)); }
+.app-text-nav        { font-size: calc(16px * var(--app-font-scale)); }
+.app-text-caption    { font-size: calc(14.5px * var(--app-font-scale)); }
+
 /* ESV passage HTML */
 .esv-passage p {
   font-family: var(--font-eb-garamond), Georgia, serif;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -97,7 +97,7 @@ html[data-font-scale="large"] {
   font-weight: 600;
   font-style: normal;
   font-size: 24px;
-  color: var(--color-primary);
+  color: var(--color-gold);
 }
 
 .esv-passage .verse-num {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,7 +20,7 @@ const Home = () => {
 
 	return (
 		<div className="px-8 max-w-[960px] mx-auto pb-8">
-			<h1 className="font-cormorant font-semibold text-[44px] text-primary text-center mt-6 mb-1">
+			<h1 className="font-cormorant font-semibold app-text-heading-lg text-primary text-center mt-6 mb-1">
 				Lutheran Lectionary
 			</h1>
 			<p className="font-eb-garamond italic text-[16px] text-gold text-center mb-6">
@@ -82,13 +82,13 @@ const Home = () => {
 								{date}
 							</h3>
 							<p
-								className="font-eb-garamond italic text-[14.5px] text-gold leading-[1.3]"
+								className="font-eb-garamond italic app-text-caption text-gold leading-[1.3]"
 								data-testid={`reading1:${monthData.name}-${date}`}
 							>
 								{reading1Display}
 							</p>
 							<p
-								className="font-eb-garamond italic text-[14.5px] text-gold leading-[1.3]"
+								className="font-eb-garamond italic app-text-caption text-gold leading-[1.3]"
 								data-testid={`reading2:${monthData.name}-${date}`}
 							>
 								{reading2Display}

--- a/src/app/utils/contrast.ts
+++ b/src/app/utils/contrast.ts
@@ -1,0 +1,28 @@
+const srgbChannelToLinear = (channel: number): number => {
+	const normalized = channel / 255;
+	return normalized <= 0.03928
+		? normalized / 12.92
+		: Math.pow((normalized + 0.055) / 1.055, 2.4);
+};
+
+const relativeLuminance = (hex: string): number => {
+	const normalizedHex = hex.replace("#", "");
+	const r = parseInt(normalizedHex.substring(0, 2), 16);
+	const g = parseInt(normalizedHex.substring(2, 4), 16);
+	const b = parseInt(normalizedHex.substring(4, 6), 16);
+
+	return (
+		0.2126 * srgbChannelToLinear(r) +
+		0.7152 * srgbChannelToLinear(g) +
+		0.0722 * srgbChannelToLinear(b)
+	);
+};
+
+export const contrastRatio = (foregroundHex: string, backgroundHex: string): number => {
+	const foregroundLuminance = relativeLuminance(foregroundHex);
+	const backgroundLuminance = relativeLuminance(backgroundHex);
+	const lighter = Math.max(foregroundLuminance, backgroundLuminance);
+	const darker = Math.min(foregroundLuminance, backgroundLuminance);
+
+	return (lighter + 0.05) / (darker + 0.05);
+};

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./helpers";
 export * from "./adjacentDay";
 export * from "./readingStyle";
+export * from "./contrast";


### PR DESCRIPTION
## Summary
- Darken light-theme gold (`#A6873A` -> `#7A5C1A`) so gold text meets WCAG AA (2.9:1 -> 5.3:1 against the light background); dark theme unchanged. Adds a tested `contrastRatio` utility.
- Extend the existing Text Size setting from passage-body-only to app-wide: headings, reading tabs, options-panel labels/rows/swatches, Prev/Next Day nav links, and home-page calendar reference lines now scale via a new `--app-font-scale` CSS variable driven by the same `fontSize` selection. No visual change at the medium/default size.
- Fix ESV's unstyled `.chapter-num` marker (e.g. "56:1") and recolor it, and the equivalent non-ESV `Verse.tsx` chapter-number spans, to the theme's gold (previously unstyled/primary-burgundy) so it reads as part of the same numbering system as the small gold verse numbers next to it.

Docs: `docs/specs/liturgical-contrast-and-scaling.md`, `docs/plans/liturgical-contrast-and-scaling-plan.md`, `docs/changes/liturgical-contrast-and-scaling-summary.md`.

## Test plan
- [x] Full unit/component suite green (170 passed), `tsc --noEmit` clean
- [x] Live browser verification (Playwright/system Chrome) for every stage: light-theme gold computed color, dark-theme gold unchanged, Text Size "Large"/"Small" resizing headings/tabs/panel/nav live and persisting across reload, ESV `/7/30` chapter-number marker color/size, non-ESV prose chapter-number marker color/size
- [x] `/code-review` pass against `main`: no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016u29tg23LwVuTZs3Q9tnqX