### PR TITLE
Scale reading headings/superscripts with Text Size; match header icon colors

### DIFF
--- a/__tests__/components/AppHeader.spec.tsx
+++ b/__tests__/components/AppHeader.spec.tsx
@@ -56,6 +56,11 @@ describe("AppHeader", () => {
 		expect(svg).toHaveAttribute("viewBox");
 	});
 
+	it("renders the options icon in the same color as the other header icons", () => {
+		renderHeader();
+		expect(screen.getByTestId("options-icon")).toHaveClass("text-primary");
+	});
+
 	it("renders the dark mode toggle", () => {
 		renderHeader();
 		expect(screen.getByRole("button", { name: "Switch to dark mode" })).toBeInTheDocument();

--- a/__tests__/components/ReadingPassage.spec.tsx
+++ b/__tests__/components/ReadingPassage.spec.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { ReadingPassage } from "@/app/components";
 import { genesisPassage } from "../../__mocks__/helloao-api";
-import { TranslationBookChapter } from "@/app/interfaces";
+import { SelectionsContext } from "@/app/contexts";
+import { Selections, TranslationBookChapter } from "@/app/interfaces";
 
 const chapterWith = (
 	content: TranslationBookChapter["chapter"]["content"]
@@ -23,10 +24,28 @@ describe("ReadingPassage", () => {
 		expect(passageHeading).toBeInTheDocument();
 	});
 
-	it("should center and size the pericope heading at 24px, capped to the poetry column width", () => {
+	it("should center and size the pericope heading at 22px (default), capped to the poetry column width", () => {
 		const passageHeading = screen.getByText("The Creation");
 
-		expect(passageHeading).toHaveClass("text-center", "text-[24px]", "max-w-[480px]", "mx-auto");
+		expect(passageHeading).toHaveClass("text-center", "text-[22px]", "max-w-[480px]", "mx-auto");
+	});
+
+	it.each([
+		["small", "text-[20px]"],
+		["large", "text-[26px]"],
+	])("should size the pericope heading at %s size", (fontSize, expectedClass) => {
+		render(
+			<SelectionsContext.Provider
+				value={{ fontSize } as unknown as Selections}
+			>
+				<ReadingPassage passageChapters={genesisPassage} />
+			</SelectionsContext.Provider>
+		);
+
+		const passageHeadings = screen.getAllByText("The Creation");
+		expect(passageHeadings[passageHeadings.length - 1]).toHaveClass(
+			expectedClass
+		);
 	});
 
 	it("should display the chapter number for the passage", () => {
@@ -97,26 +116,40 @@ describe("ReadingPassage poetry column", () => {
 });
 
 describe("ReadingPassage hebrew_subtitle", () => {
-	it("renders the subtitle text, centered, italic, and width-capped", () => {
-		render(
-			<ReadingPassage
-				passageChapters={chapterWith([
-					{
-						type: "hebrew_subtitle",
-						content: ["A Psalm. A song for the Sabbath day."],
-					},
-					{ type: "verse", number: 1, content: ["A verse line"] },
-				])}
-			/>
-		);
+	const contentWithSubtitle = chapterWith([
+		{
+			type: "hebrew_subtitle",
+			content: ["A Psalm. A song for the Sabbath day."],
+		},
+		{ type: "verse", number: 1, content: ["A verse line"] },
+	]);
+
+	it("renders the subtitle at the default (medium) size, centered, italic, and width-capped", () => {
+		render(<ReadingPassage passageChapters={contentWithSubtitle} />);
 
 		const subtitle = screen.getByText("A Psalm. A song for the Sabbath day.");
 		expect(subtitle).toHaveClass(
 			"italic",
 			"text-center",
-			"text-[15px]",
+			"text-[19px]",
 			"max-w-[480px]",
 			"mx-auto"
 		);
+	});
+
+	it.each([
+		["small", "text-[17px]"],
+		["large", "text-[22px]"],
+	])("renders the subtitle at %s size", (fontSize, expectedClass) => {
+		render(
+			<SelectionsContext.Provider
+				value={{ fontSize } as unknown as Selections}
+			>
+				<ReadingPassage passageChapters={contentWithSubtitle} />
+			</SelectionsContext.Provider>
+		);
+
+		const subtitle = screen.getByText("A Psalm. A song for the Sabbath day.");
+		expect(subtitle).toHaveClass(expectedClass);
 	});
 });

--- a/__tests__/components/VersePassage.spec.tsx
+++ b/__tests__/components/VersePassage.spec.tsx
@@ -2,8 +2,9 @@ import { render, screen } from "@testing-library/react";
 import { lukeTranslationBookChapter } from "../../__mocks__/content";
 import lectionary from "@/app/constants/lectionary";
 import { VersePassage } from "@/app/components";
+import { SelectionsContext } from "@/app/contexts";
 import { BookId } from "@/app/enums";
-import { TranslationBookChapter } from "@/app/interfaces";
+import { Selections, TranslationBookChapter } from "@/app/interfaces";
 
 const singleVerseChapter = (
 	content: TranslationBookChapter["chapter"]["content"]
@@ -111,17 +112,19 @@ describe("VersePassage hebrew_subtitle", () => {
 		verses: { first: 1, last: 2 },
 	};
 
-	it("renders the subtitle text, centered, italic, and width-capped", () => {
+	const contentWithSubtitle = singleVerseChapter([
+		{ type: "verse", number: 1, content: ["A verse line"] },
+		{
+			type: "hebrew_subtitle",
+			content: ["A Psalm. A song for the Sabbath day."],
+		},
+		{ type: "verse", number: 2, content: ["Another verse line"] },
+	]);
+
+	it("renders the subtitle at the default (medium) size, centered, italic, and width-capped", () => {
 		render(
 			<VersePassage
-				passageChapter={singleVerseChapter([
-					{ type: "verse", number: 1, content: ["A verse line"] },
-					{
-						type: "hebrew_subtitle",
-						content: ["A Psalm. A song for the Sabbath day."],
-					},
-					{ type: "verse", number: 2, content: ["Another verse line"] },
-				])}
+				passageChapter={contentWithSubtitle}
 				readingInformation={readingInformation}
 			/>
 		);
@@ -130,9 +133,77 @@ describe("VersePassage hebrew_subtitle", () => {
 		expect(subtitle).toHaveClass(
 			"italic",
 			"text-center",
-			"text-[15px]",
+			"text-[19px]",
 			"max-w-[480px]",
 			"mx-auto"
 		);
+	});
+
+	it.each([
+		["small", "text-[17px]"],
+		["large", "text-[22px]"],
+	])("renders the subtitle at %s size", (fontSize, expectedClass) => {
+		render(
+			<SelectionsContext.Provider
+				value={{ fontSize } as unknown as Selections}
+			>
+				<VersePassage
+					passageChapter={contentWithSubtitle}
+					readingInformation={readingInformation}
+				/>
+			</SelectionsContext.Provider>
+		);
+
+		const subtitle = screen.getByText("A Psalm. A song for the Sabbath day.");
+		expect(subtitle).toHaveClass(expectedClass);
+	});
+});
+
+describe("VersePassage heading", () => {
+	const readingInformation = {
+		bookId: BookId.Psalms,
+		verses: { first: 1, last: 2 },
+	};
+
+	const contentWithHeading = singleVerseChapter([
+		{ type: "verse", number: 1, content: ["A verse line"] },
+		{ type: "heading", content: ["Save Me, O My God"] },
+		{ type: "verse", number: 2, content: ["Another verse line"] },
+	]);
+
+	it("renders the heading at the default (medium) size, centered, and width-capped", () => {
+		render(
+			<VersePassage
+				passageChapter={contentWithHeading}
+				readingInformation={readingInformation}
+			/>
+		);
+
+		const heading = screen.getByText("Save Me, O My God");
+		expect(heading).toHaveClass(
+			"text-center",
+			"text-[22px]",
+			"max-w-[480px]",
+			"mx-auto"
+		);
+	});
+
+	it.each([
+		["small", "text-[20px]"],
+		["large", "text-[26px]"],
+	])("renders the heading at %s size", (fontSize, expectedClass) => {
+		render(
+			<SelectionsContext.Provider
+				value={{ fontSize } as unknown as Selections}
+			>
+				<VersePassage
+					passageChapter={contentWithHeading}
+					readingInformation={readingInformation}
+				/>
+			</SelectionsContext.Provider>
+		);
+
+		const heading = screen.getByText("Save Me, O My God");
+		expect(heading).toHaveClass(expectedClass);
 	});
 });

--- a/__tests__/utils/readingStyle.spec.ts
+++ b/__tests__/utils/readingStyle.spec.ts
@@ -1,0 +1,19 @@
+import { headingSizeClass } from "@/app/utils/readingStyle";
+
+describe("headingSizeClass", () => {
+	it("returns text-[20px] for small", () => {
+		expect(headingSizeClass("small")).toBe("text-[20px]");
+	});
+
+	it("returns text-[22px] for medium", () => {
+		expect(headingSizeClass("medium")).toBe("text-[22px]");
+	});
+
+	it("returns text-[22px] for undefined (default)", () => {
+		expect(headingSizeClass(undefined)).toBe("text-[22px]");
+	});
+
+	it("returns text-[26px] for large", () => {
+		expect(headingSizeClass("large")).toBe("text-[26px]");
+	});
+});

--- a/docs/plans/reading-heading-scaling-plan.md
+++ b/docs/plans/reading-heading-scaling-plan.md
@@ -1,0 +1,124 @@
+# Plan: Scale Reading Headings & Superscripts with Text Size
+
+Spec: `docs/specs/reading-heading-scaling.md`. Two rendering paths
+(HelloAO, ESV) for the same conceptual fix; staged so each is its own
+commit and can be reverted independently.
+
+## Process
+
+Same discipline as `docs/plans/liturgical-contrast-and-scaling-plan.md`:
+
+**Hybrid outside-in TDD** for all new code, applied per stage:
+- Prefer a test at the highest boundary that exercises the change the way a
+  real consumer does (component render with a `SelectionsContext.Provider`
+  wrapping different `fontSize` values).
+- Drop to a pure-function unit test only where component testing is
+  impractical (the new `headingSizeClass` helper).
+- Within a stage: write the failing test first, implement until green, then
+  move on.
+
+**End of every stage**, before moving on:
+1. **QA pass** — run the full test suite, re-read the diff against the spec
+   section it implements, and spot-check in the browser rather than
+   trusting green tests alone (jsdom doesn't compute rendered CSS from
+   `calc()`/CSS-variable rules, so the browser check is the real
+   verification for anything CSS-only).
+2. **Rubber-duck review** — walk back through what the stage was supposed
+   to do, what was implemented, and why, looking specifically for
+   mismatches with the spec, uncovered edge cases, and tests written to
+   match the implementation instead of the spec.
+3. If QA or rubber-duck review surfaces a problem, fix it and repeat
+   (max 3 attempts for that stage). If still unresolved after 3 attempts,
+   stop and hand the stage back with a clear description of what's failing
+   and what's been tried — do not proceed to the next stage.
+
+## Stage 1 — `headingSizeClass` helper
+
+1. Write failing tests in `__tests__/utils/readingStyle.spec.ts` (new file)
+   for `headingSizeClass(fontSize)`: `"small"` → `text-[20px]`,
+   `undefined`/`"medium"` → `text-[22px]`, `"large"` → `text-[26px]`.
+2. Implement `headingSizeClass` in `src/app/utils/readingStyle.ts`, same
+   shape as the existing `fontSizeClass`.
+3. QA + rubber-duck review. Confirm the three return values match the
+   spec's heading table exactly, and that `fontSizeClass` itself is
+   untouched (superscription reuses it as-is, no new export needed there).
+
+## Stage 2 — Wire HelloAO heading + superscript to Text Size
+
+1. Write failing tests:
+   - `ReadingPassage.spec.tsx`: update the existing "centers and sizes the
+     pericope heading at 24px" test to assert `text-[22px]` at default
+     (no provider / medium), and add cases wrapping in
+     `SelectionsContext.Provider` with `fontSize: "small"` /
+     `fontSize: "large"` asserting `text-[20px]` / `text-[26px]`.
+   - Same pattern for the existing hebrew_subtitle test: default asserts
+     `text-[19px]` (was `text-[15px]`), small/large cases assert
+     `text-[17px]` / `text-[22px]`.
+   - Mirror both sets of changes in `VersePassage.spec.tsx` against its
+     equivalent existing tests.
+2. In `ReadingPassage.tsx` and `VersePassage.tsx`: import
+   `SelectionsContext` and `useContext` from React, read
+   `selections.fontSize`, replace the heading's `text-[24px]` with
+   `headingSizeClass(selections.fontSize)` and the subtitle's `text-[15px]`
+   with `fontSizeClass(selections.fontSize)`.
+3. QA + rubber-duck review. Run full suite. In-browser, open Psalm 58
+   (Jan 30 or Aug 3) on a non-ESV translation and cycle Text Size through
+   Small/Medium/Large, confirming the heading and superscript resize per
+   the spec table and the reading text resizes alongside them as before.
+
+## Stage 3 — ESV heading + superscript sizing
+
+1. No dedicated unit test — CSS-only change, no JS boundary (same
+   precedent as the ESV chapter-number color stage in the prior plan).
+2. In `globals.css`:
+   - Add explicit base (medium) sizes:
+     ```css
+     .esv-passage > h3 { font-size: 22px; }
+     .esv-passage > h4.psalm-title { font-size: 19px; }
+     ```
+   - Remove the old flat `font-size: 15px` from the existing
+     `.esv-passage > h4.psalm-title` rule (superseded by the base rule
+     above).
+   - Add small/large overrides alongside the existing
+     `.esv-passage.size-small p` / `.esv-passage.size-large p` rules:
+     ```css
+     .esv-passage.size-small > h3 { font-size: 20px; }
+     .esv-passage.size-small > h4.psalm-title { font-size: 17px; }
+     .esv-passage.size-large > h3 { font-size: 26px; }
+     .esv-passage.size-large > h4.psalm-title { font-size: 22px; }
+     ```
+   - No new rule for `.psalm-book` — it's covered by `.esv-passage > h3`
+     already (per spec, deliberately not special-cased).
+3. QA + rubber-duck review. In-browser, open Psalm 58 (ESV) and cycle Text
+   Size through all three tiers, confirming sizes match Stage 2's HelloAO
+   values (parity). Additionally check Sept 6 (Psalm 90) or Sept 23
+   (Psalm 107) on ESV to confirm the `psalm-book` divider ("Book Four" /
+   "Book Five") resizes identically to the pericope title beneath it.
+
+## Stage 4 — End-to-end verification
+
+1. Run full unit/test suite + type-check.
+2. Manual browser pass:
+   - Psalm 58 on a HelloAO translation and on ESV, all three Text Size
+     tiers: confirm heading/superscript/reading-text sizes match between
+     the two paths at each tier.
+   - Psalm 90 or Psalm 107 on ESV: confirm the `psalm-book` divider scales
+     with the pericope title.
+   - A non-Psalm reading with a plain `heading` line (e.g. Genesis) on a
+     HelloAO translation: confirm the section-heading resize applies there
+     too, not just Psalms.
+   - Dark theme: confirm unaffected.
+   - Chrome text scaling (`--app-font-scale`, from the prior feature):
+     confirm unaffected — switching Text Size should not double-scale
+     anything covered by that feature.
+3. `/code-review` pass before calling it done.
+4. QA + rubber-duck review covering the whole feature set end-to-end — the
+   final gate before handing back as done.
+
+## Explicitly out of scope for this pass
+
+- A distinct/separate size treatment for `.psalm-book` vs. the pericope
+  title `h3`.
+- Any change to `--app-font-scale` or the elements it already covers.
+- Styling the ESV `h2` element (confirmed unused in live API output) or
+  the `.footnotes` `h3`.

--- a/docs/specs/reading-heading-scaling.md
+++ b/docs/specs/reading-heading-scaling.md
@@ -1,0 +1,147 @@
+# Spec: Scale Reading Headings & Superscripts with Text Size
+
+Follow-up to `docs/specs/liturgical-contrast-and-scaling.md`. Addresses a
+mobile-readability gap: the section heading and Psalm-superscription text
+that appear inside a reading passage are hardcoded pixel values, unaffected
+by the Text Size (Small/Medium/Large) control that already resizes
+everything else in the passage.
+
+## Problem
+
+Two elements appear inside every reading passage, on both the HelloAO and
+ESV rendering paths, and neither responds to Text Size today:
+
+| Element | HelloAO source | ESV source | Current size |
+|---|---|---|---|
+| Section heading | `ReadingPassage.tsx` / `VersePassage.tsx`, `line.type === "heading"` → `<h4 class="... text-primary ... text-[24px] ...">` | ESV API HTML `<h3>` (pericope title, and `<h3 class="psalm-book">` — see below) | HelloAO: flat `24px`. ESV: unset — falls back to the browser default `h3` size (~1.17em of ambient font, ~18.7px), the only place in the app relying on an unstyled UA default rather than an explicit value. |
+| Superscription | `line.type === "hebrew_subtitle"` → `<p class="... text-gold italic ... text-[15px] ...">` | ESV API HTML `<h4 class="psalm-title">` | HelloAO: flat `15px`. ESV: explicit `15px` (`globals.css` `.esv-passage > h4.psalm-title`). |
+| Reading text (for comparison) | `Verse.tsx`, via `fontSizeClass` | `.esv-passage p`, via `.size-small`/`.size-large` wrapper class | 17 / **19** / 22px (small/medium/large) |
+
+Both elements are visually distinct treatments (bigger serif heading,
+smaller italic gold caption) rather than being sized relative to the
+reading text a user actually chose. On mobile, a user who picks "Large" for
+readability sees no benefit on these two elements — they're stuck at their
+flat value.
+
+### The `psalm-book` case
+
+Confirmed by fetching live ESV API output (`Psalm 1-3`, `Psalm 107`): when
+a reading's first chapter is the start of one of the Psalter's five
+traditional book divisions (chapters 1, 42, 73, 90, 107), the ESV API
+inserts `<h3 class="psalm-book">Book One</h3>` (etc.) immediately before
+the pericope title `<h3>`. Two lectionary dates hit this: **Sept 6** (Psalm
+90 → "Book Four") and **Sept 23** (Psalm 107 → "Book Five"). It's ESV-only
+— confirmed against several HelloAO translations' raw chapter JSON
+(ASV, WEB, KJV, YLT) that the `ChapterContent` schema has no book-division
+concept at all (only `heading` / `hebrew_subtitle` / `verse` /
+`line_break`). It already renders identically to the pericope title today
+(same tag, no distinguishing CSS) and is caught by the same `.esv-passage >
+h3` selector used below — **decision: leave it that way**, no separate
+selector or distinct treatment. Consistent with "only touch font-size,
+nothing else" for this pass; a bespoke treatment for two dates on one
+translation isn't warranted here.
+
+## Reference point: unstyled ESV output
+
+Dropping ESV's raw API HTML into a page with no custom CSS (default
+browser stylesheet, 16px base) gives:
+
+- reading text (`p`): 1em → 16px
+- section heading (`h3`): 1.17em → ~18.7px (~1.17× body)
+- superscription (`h4`): 1em → 16px (same size as body; distinguished only
+  by bold weight, not size)
+
+This is the ratio being adopted as the target relationship, rounded to
+clean values and applied against this app's three reading-text sizes
+(17/19/22) rather than a single 16px base.
+
+## Decision
+
+Tie both elements' size to the existing **Text Size** setting
+(`selections.fontSize`), not the app-wide chrome scale
+(`--app-font-scale`) added in the prior pass — these elements live inside
+the reading passage, so the passage's own text-size control is the more
+relevant driver.
+
+**Section heading** — scale at ~1.17× reading text:
+
+| fontSize | reading text | heading |
+|---|---|---|
+| small | 17px | **20px** |
+| medium (default) | 19px | **22px** |
+| large | 22px | **26px** |
+
+**Superscription** — scale at 1× reading text (identical to body size,
+matching the unstyled-ESV reference point):
+
+| fontSize | reading text | superscription |
+|---|---|---|
+| small | 17px | **17px** |
+| medium (default) | 19px | **19px** |
+| large | 22px | **22px** |
+
+This is an intentional change to the medium/default baseline too, not
+just small/large — heading drops from a flat 24px to 22px, superscription
+grows from a flat 15px to 19px. Confirmed acceptable: both elements move
+to be proportionate to reading text at every tier, not just at the
+extremes.
+
+No other styling changes — heading keeps its Cormorant/semibold/maroon/
+centered treatment, superscription keeps its EB Garamond/italic/gold
+treatment. Only `font-size` becomes size-aware instead of a flat value.
+
+### HelloAO implementation shape
+
+`ReadingPassage.tsx` and `VersePassage.tsx` don't currently read
+`SelectionsContext` (only the leaf `Verse` component does). Both need to
+read `selections.fontSize` and use two size-class helpers in
+`readingStyle.ts`:
+
+- `headingSizeClass(fontSize)` — new function, same shape as
+  `fontSizeClass`, returning `text-[20px]` / `text-[22px]` / `text-[26px]`.
+- Superscription reuses the **existing** `fontSizeClass(fontSize)` directly
+  (17/19/22 is already what it returns) — no new function needed there.
+
+### ESV implementation shape
+
+`EsvPassage.tsx` already applies `.size-small` / `.size-large` (medium =
+no modifier class) to the `.esv-passage` wrapper. This is pure CSS: add
+explicit base sizes to `.esv-passage > h3` and `.esv-passage >
+h4.psalm-title` (currently unset / flat `15px`), plus `.size-small` /
+`.size-large` overrides, mirroring the existing `.esv-passage.size-small p`
+/ `.esv-passage.size-large p` pattern. `.psalm-book` is not special-cased
+(see above) — it's covered by the same `.esv-passage > h3` rule. No
+component/JS change on the ESV path.
+
+## Acceptance criteria
+
+- On a non-ESV (HelloAO) reading containing both a section heading and a
+  Psalm superscription (e.g. Psalm 58 — used on Jan 30 and Aug 3), cycling
+  Text Size through Small/Medium/Large visibly resizes both elements to
+  20/22/26px (heading) and 17/19/22px (superscript), matching the table
+  above, and the reading text resizes alongside them as it already does.
+- On an ESV reading of the same passage, the same three Text Size settings
+  produce the same heading/superscript sizes as the HelloAO path (parity
+  between translations).
+- On ESV readings for Sept 6 (Psalm 90) and Sept 23 (Psalm 107), the
+  `psalm-book` divider ("Book Four" / "Book Five") resizes identically to
+  the pericope title beneath it at every Text Size tier.
+- Medium (default) renders at 22px heading / 19px superscript on both
+  paths — the new baseline, replacing the old flat 24px / 15px.
+- No change to color, weight, italic, font-family, alignment, or max-width
+  of either element — only `font-size` is affected.
+- Dark theme, chrome text scaling (`--app-font-scale`), and the existing
+  passage-body Text Size behavior are all unaffected.
+
+## Out of scope
+
+- Changing the visual *character* of either element (e.g. making the
+  superscript non-italic or the heading non-bold) — only their sizing
+  relative to reading text.
+- Any change to `--app-font-scale` or the chrome elements it already
+  covers.
+- A distinct treatment for `.psalm-book` vs. the plain pericope title.
+- The ESV `h2` element or the `.footnotes` `h3` (deliberately excluded by
+  the existing `.esv-passage > h3` child-combinator scoping) — confirmed
+  live against the ESV API that `h2` never appears in fetched passage
+  content; this pass doesn't add sizing for it.

--- a/src/app/components/AppHeader.tsx
+++ b/src/app/components/AppHeader.tsx
@@ -50,7 +50,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({ translations }) => {
 							strokeWidth={1.4}
 							strokeLinecap="round"
 							strokeLinejoin="round"
-							className="text-gold"
+							className="text-primary"
 						>
 							<line x1="4" y1="6" x2="20" y2="6" />
 							<circle cx="8" cy="6" r="2" fill="currentColor" stroke="none" />

--- a/src/app/components/ReadingPassage.tsx
+++ b/src/app/components/ReadingPassage.tsx
@@ -1,11 +1,12 @@
-import React from "react";
+import React, { useContext } from "react";
 import { PassageUnavailable, Verse } from "@/app/components";
 import {
 	ChapterHebrewSubtitle,
 	ChapterVerse,
 	TranslationBookChapter,
 } from "@/app/interfaces";
-import { isPoetryPassage } from "@/app/utils";
+import { SelectionsContext } from "@/app/contexts";
+import { fontSizeClass, headingSizeClass, isPoetryPassage } from "@/app/utils";
 
 interface ReadingPassageProps {
 	passageChapters: TranslationBookChapter[];
@@ -21,6 +22,7 @@ export const ReadingPassage: React.FC<ReadingPassageProps> = ({
 	const hasPoetry = chaptersWithData.some((bookChapter) =>
 		isPoetryPassage(bookChapter.chapter.content)
 	);
+	const selections = useContext(SelectionsContext);
 
 	return (
 		<div className={hasPoetry ? "poetry-passage" : undefined}>
@@ -32,7 +34,7 @@ export const ReadingPassage: React.FC<ReadingPassageProps> = ({
 						const baseKey = `${bookChapter.book.id}:${bookChapter.chapter.number}:${index}`;
 						if (line.type === "heading") {
 							node = (
-								<h4 key={`${baseKey}-heading`} className="font-cormorant font-semibold text-primary text-center text-[24px] max-w-[480px] mx-auto pt-3">
+								<h4 key={`${baseKey}-heading`} className={`font-cormorant font-semibold text-primary text-center ${headingSizeClass(selections.fontSize)} max-w-[480px] mx-auto pt-3`}>
 									{line.content
 										.filter((text) => typeof text === "string")
 										.join(" ")}
@@ -42,7 +44,7 @@ export const ReadingPassage: React.FC<ReadingPassageProps> = ({
 							node = (
 								<p
 									key={`${baseKey}-subtitle`}
-									className="font-eb-garamond italic text-gold text-center text-[15px] max-w-[480px] mx-auto mb-[30px]"
+									className={`font-eb-garamond italic text-gold text-center ${fontSizeClass(selections.fontSize)} max-w-[480px] mx-auto mb-[30px]`}
 								>
 									{(line as ChapterHebrewSubtitle).content
 										.filter((text) => typeof text === "string")

--- a/src/app/components/VersePassage.tsx
+++ b/src/app/components/VersePassage.tsx
@@ -1,3 +1,4 @@
+import { useContext } from "react";
 import {
 	ChapterHebrewSubtitle,
 	ChapterVerse,
@@ -5,7 +6,8 @@ import {
 	TranslationBookChapter,
 	Verses,
 } from "@/app/interfaces";
-import { isPoetryPassage } from "@/app/utils";
+import { SelectionsContext } from "@/app/contexts";
+import { fontSizeClass, headingSizeClass, isPoetryPassage } from "@/app/utils";
 import { PassageUnavailable } from "./PassageUnavailable";
 import { Verse } from "./Verse";
 
@@ -32,6 +34,7 @@ export const VersePassage: React.FC<VersePassageProps> = ({
 		lastVerseIndex + 1
 	);
 	const hasPoetry = isPoetryPassage(verseContents ?? []);
+	const selections = useContext(SelectionsContext);
 
 	return (
 		<div className={hasPoetry ? "poetry-passage" : undefined}>
@@ -41,7 +44,7 @@ export const VersePassage: React.FC<VersePassageProps> = ({
 				const baseKey = `${passageChapter.book.id}:${passageChapter.chapter.number}:${index}`;
 				if (line.type === "heading") {
 					node = (
-						<h4 key={`${baseKey}:heading`} className="font-cormorant font-semibold text-primary text-center text-[24px] max-w-[480px] mx-auto">
+						<h4 key={`${baseKey}:heading`} className={`font-cormorant font-semibold text-primary text-center ${headingSizeClass(selections.fontSize)} max-w-[480px] mx-auto`}>
 							{line.content
 								.filter((text) => typeof text === "string")
 								.join(" ")}
@@ -51,7 +54,7 @@ export const VersePassage: React.FC<VersePassageProps> = ({
 					node = (
 						<p
 							key={`${baseKey}:subtitle`}
-							className="font-eb-garamond italic text-gold text-center text-[15px] max-w-[480px] mx-auto mb-[30px]"
+							className={`font-eb-garamond italic text-gold text-center ${fontSizeClass(selections.fontSize)} max-w-[480px] mx-auto mb-[30px]`}
 						>
 							{(line as ChapterHebrewSubtitle).content
 								.filter((text) => typeof text === "string")

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -134,25 +134,22 @@ html[data-font-scale="large"] {
 }
 
 /* Psalm superscription (e.g. "To the choirmaster..."); matches the non-ESV
-   hebrew_subtitle styling. */
+   hebrew_subtitle styling. Base (medium) font-size scales with reading
+   Text Size below, alongside the pericope title / psalm-book divider. */
 .esv-passage > h4.psalm-title {
   font-family: var(--font-eb-garamond), Georgia, serif;
   font-style: italic;
   font-weight: 400;
+  font-size: 19px;
   color: var(--color-gold);
   margin-bottom: 30px;
 }
 
-/* Pericope title / psalm-book divider and superscription sizing, scaled
-   with the reading Text Size setting (17/19/22 body -> 20/22/26 heading,
-   1:1 for the superscript) to match the non-ESV heading/hebrew_subtitle
-   sizes. */
+/* Pericope title / psalm-book divider sizing, scaled with the reading Text
+   Size setting (17/19/22 body -> 20/22/26 heading) to match the non-ESV
+   heading treatment. */
 .esv-passage > h3 {
   font-size: 22px;
-}
-
-.esv-passage > h4.psalm-title {
-  font-size: 19px;
 }
 
 .esv-passage.size-small > h3 {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -147,12 +147,15 @@ html[data-font-scale="large"] {
 
 /* Pericope title / psalm-book divider sizing, scaled with the reading Text
    Size setting (17/19/22 body -> 20/22/26 heading) to match the non-ESV
-   heading treatment. */
-.esv-passage > h3 {
+   heading treatment. The "Footnotes" h3 (nested in .footnotes) matches the
+   same table, since it's still just an h3 in the same document. */
+.esv-passage > h3,
+.esv-passage .footnotes h3 {
   font-size: 22px;
 }
 
-.esv-passage.size-small > h3 {
+.esv-passage.size-small > h3,
+.esv-passage.size-small .footnotes h3 {
   font-size: 20px;
 }
 
@@ -160,7 +163,8 @@ html[data-font-scale="large"] {
   font-size: 17px;
 }
 
-.esv-passage.size-large > h3 {
+.esv-passage.size-large > h3,
+.esv-passage.size-large .footnotes h3 {
   font-size: 26px;
 }
 
@@ -168,9 +172,20 @@ html[data-font-scale="large"] {
   font-size: 22px;
 }
 
+/* Attribution link (ESV license requires a link to esv.org on every page
+   showing quoted text, but sets no size/prominence rule) -- scaled 1:1
+   with reading text, matching the superscript's ratio. */
 .esv-passage .copyright {
-  font-size: 0.75rem;
+  font-size: 19px;
   color: var(--color-gold);
+}
+
+.esv-passage.size-small .copyright {
+  font-size: 17px;
+}
+
+.esv-passage.size-large .copyright {
+  font-size: 22px;
 }
 
 /* Poetry column: shrink-wrap to the longest line, cap the width, then centre

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -133,15 +133,42 @@ html[data-font-scale="large"] {
   margin-right: auto;
 }
 
-/* Psalm superscription (e.g. "To the choirmaster..."); read as a small
-   caption under the title, matching the non-ESV hebrew_subtitle styling. */
+/* Psalm superscription (e.g. "To the choirmaster..."); matches the non-ESV
+   hebrew_subtitle styling. */
 .esv-passage > h4.psalm-title {
   font-family: var(--font-eb-garamond), Georgia, serif;
   font-style: italic;
   font-weight: 400;
-  font-size: 15px;
   color: var(--color-gold);
   margin-bottom: 30px;
+}
+
+/* Pericope title / psalm-book divider and superscription sizing, scaled
+   with the reading Text Size setting (17/19/22 body -> 20/22/26 heading,
+   1:1 for the superscript) to match the non-ESV heading/hebrew_subtitle
+   sizes. */
+.esv-passage > h3 {
+  font-size: 22px;
+}
+
+.esv-passage > h4.psalm-title {
+  font-size: 19px;
+}
+
+.esv-passage.size-small > h3 {
+  font-size: 20px;
+}
+
+.esv-passage.size-small > h4.psalm-title {
+  font-size: 17px;
+}
+
+.esv-passage.size-large > h3 {
+  font-size: 26px;
+}
+
+.esv-passage.size-large > h4.psalm-title {
+  font-size: 22px;
 }
 
 .esv-passage .copyright {

--- a/src/app/utils/readingStyle.ts
+++ b/src/app/utils/readingStyle.ts
@@ -13,3 +13,14 @@ export const fontSizeClass = (fontSize?: FontSize): string => {
 			return "text-[19px]";
 	}
 };
+
+export const headingSizeClass = (fontSize?: FontSize): string => {
+	switch (fontSize) {
+		case "small":
+			return "text-[20px]";
+		case "large":
+			return "text-[26px]";
+		default:
+			return "text-[22px]";
+	}
+};


### PR DESCRIPTION
## Summary
- Section headings and Psalm superscriptions inside a reading passage (both HelloAO and ESV rendering paths) now scale with the Text Size setting instead of being hardcoded, fixing a mobile-readability gap.
- Extends the same scaling to the ESV "Footnotes" heading and the ESV attribution link (previously fixed at 12px — confirmed against api.esv.org's terms that there's no size/prominence requirement, so this was a free styling choice).
- Fixes a header icon inconsistency: the options icon used `text-gold` while the home icon and dark-mode toggle used `text-primary`, with no state-based meaning behind the difference (unlike gold/primary usage elsewhere, e.g. active/inactive tabs).

See `docs/specs/reading-heading-scaling.md` and `docs/plans/reading-heading-scaling-plan.md` for the full design rationale, including the discovered ESV `psalm-book` divider edge case (Sept 6 / Sept 23 lectionary dates).

## Test plan
- [x] Full unit test suite green (187 tests, 24 suites)
- [x] `tsc --noEmit` clean
- [x] Manual browser verification across Small/Medium/Large Text Size on both HelloAO and ESV translations (Psalm 58: Jan 30 / Aug 3)
- [x] Verified the ESV `psalm-book` divider ("Book Four"/"Book Five", Sept 6 / Sept 23) scales alongside the pericope title
- [x] Verified dark theme and the existing app-wide chrome font scale (`--app-font-scale`) are unaffected (no double-scaling)
- [x] Verified options icon color matches in both light and dark theme
- [x] `/code-review` pass (one cosmetic finding — duplicate CSS selector — found and fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016u29tg23LwVuTZs3Q9tnqX